### PR TITLE
Drop "using namespace" in header files. Fix clang-tidy/clazy findings.

### DIFF
--- a/include/bluez-dbus-cpp/Adapter1.h
+++ b/include/bluez-dbus-cpp/Adapter1.h
@@ -11,13 +11,11 @@
 namespace org {
 namespace bluez {
 
-using namespace sdbus;
-
-class Adapter1 : public ProxyInterfaces<org::bluez::Adapter1_proxy>
+class Adapter1 : public sdbus::ProxyInterfaces<org::bluez::Adapter1_proxy>
 {
 public:
-    Adapter1( IConnection& connection, std::string destination, std::string objectPath )
-        : ProxyInterfaces{ connection, std::move(destination), std::move(objectPath) }
+    Adapter1( sdbus::IConnection& connection, std::string destination, std::string objectPath )
+        : sdbus::ProxyInterfaces<org::bluez::Adapter1_proxy>{ connection, std::move(destination), std::move(objectPath) }
     {
         registerProxy();
     }

--- a/include/bluez-dbus-cpp/GattApplication1.h
+++ b/include/bluez-dbus-cpp/GattApplication1.h
@@ -17,14 +17,12 @@
 namespace org {
 namespace bluez {
 
-using namespace sdbus;
-
 class GattApplication1 :
-    public AdaptorInterfaces<ObjectManager_adaptor>,
+    public sdbus::AdaptorInterfaces<sdbus::ObjectManager_adaptor>,
     public std::enable_shared_from_this<GattApplication1>
 {
 public:
-    GattApplication1( std::shared_ptr<IConnection> connection, std::string objectPath )
+    GattApplication1( std::shared_ptr<sdbus::IConnection> connection, std::string objectPath )
         : AdaptorInterfaces{ *connection, objectPath },
           connection_{ connection },
           path_{ std::move(objectPath) }
@@ -68,7 +66,7 @@ public:
         return path_;
     }
 
-    std::shared_ptr<IConnection> getConnection() const
+    std::shared_ptr<sdbus::IConnection> getConnection() const
     {
         return connection_;
     }
@@ -87,7 +85,7 @@ public:
 
 protected:
     std::string path_;
-    std::shared_ptr<IConnection> connection_;
+    std::shared_ptr<sdbus::IConnection> connection_;
     std::vector<std::shared_ptr<GattService1>> services_;
 };
 

--- a/include/bluez-dbus-cpp/GattApplication1.h
+++ b/include/bluez-dbus-cpp/GattApplication1.h
@@ -38,7 +38,7 @@ public:
 public:
     void addService( std::shared_ptr<GattService1> service )
     {
-        for( auto serv : services_ )
+        for( const auto & serv : services_ )
         {
             if( serv == service )
                 throw std::invalid_argument(std::string("GattApplication::addService '") + service->getPath() + std::string("' already registered!"));

--- a/include/bluez-dbus-cpp/GattCharacteristic1.h
+++ b/include/bluez-dbus-cpp/GattCharacteristic1.h
@@ -21,10 +21,8 @@ namespace bluez {
 // Forward declarations
 class GattService1;
 
-using namespace sdbus;
-
 class GattCharacteristic1 :
-    public AdaptorInterfaces<GattCharacteristic1_adaptor, PropertiesExt_adaptor>,
+    public sdbus::AdaptorInterfaces<GattCharacteristic1_adaptor, PropertiesExt_adaptor>,
     public std::enable_shared_from_this<GattCharacteristic1>
 {
     static constexpr const char* INTERFACE_NAME = "org.bluez.GattCharacteristic1";
@@ -50,7 +48,7 @@ protected:
     virtual void addDescriptor( std::shared_ptr<GattDescriptor1> descriptor );
     virtual void removeDescriptor( std::shared_ptr<GattDescriptor1> descriptor );
     const std::string& getPath() const;
-    const std::shared_ptr<IConnection> getConnection() const;
+    const std::shared_ptr<sdbus::IConnection> getConnection() const;
 
 protected:
     /**

--- a/include/bluez-dbus-cpp/GattDescriptor1.h
+++ b/include/bluez-dbus-cpp/GattDescriptor1.h
@@ -17,10 +17,8 @@ namespace bluez {
 // Forward declarations
 class GattCharacteristic1;
 
-using namespace sdbus;
-
 class GattDescriptor1 :
-    public AdaptorInterfaces<GattDescriptor1_adaptor, PropertiesExt_adaptor>,
+    public sdbus::AdaptorInterfaces<GattDescriptor1_adaptor, PropertiesExt_adaptor>,
     public std::enable_shared_from_this<GattDescriptor1>
 {
 public:

--- a/include/bluez-dbus-cpp/GattManager1.h
+++ b/include/bluez-dbus-cpp/GattManager1.h
@@ -11,8 +11,6 @@
 namespace org {
 namespace bluez {
 
-using namespace sdbus;
-
 class GattManager1 :
     public std::enable_shared_from_this<GattManager1>
 {
@@ -20,7 +18,7 @@ class GattManager1 :
     static constexpr const char* INTERFACE_NAME = "org.bluez.GattManager1";
 
 public:
-    GattManager1( IConnection& connection, std::string destination, std::string objectPath )
+    GattManager1( sdbus::IConnection& connection, std::string destination, std::string objectPath )
         : proxy_{ createProxy( connection, std::move(destination), std::move(objectPath) ) }
     {
         proxy_->finishRegistration();
@@ -43,7 +41,7 @@ public:
         proxy_->callMethod("RegisterApplication").onInterface(INTERFACE_NAME).withArguments(application, options);
     }
 
-    AsyncMethodInvoker RegisterApplicationAsync( const sdbus::ObjectPath& application, const std::map<std::string, sdbus::Variant>& options )
+    sdbus::AsyncMethodInvoker RegisterApplicationAsync( const sdbus::ObjectPath& application, const std::map<std::string, sdbus::Variant>& options )
     {
         return proxy_->callMethodAsync("RegisterApplication").onInterface(INTERFACE_NAME).withArguments(application, options);
     }

--- a/include/bluez-dbus-cpp/GattService1.h
+++ b/include/bluez-dbus-cpp/GattService1.h
@@ -18,10 +18,8 @@ namespace bluez {
 // Forward declarations
 class GattApplication1;
 
-using namespace sdbus;
-
 class GattService1 :
-    public AdaptorInterfaces<GattService1_adaptor, PropertiesExt_adaptor>,
+    public sdbus::AdaptorInterfaces<GattService1_adaptor, PropertiesExt_adaptor>,
     public std::enable_shared_from_this<GattService1>
 {
     GattService1( const GattService1& service ) = delete;
@@ -40,7 +38,7 @@ public:
     virtual void addSubService( std::shared_ptr<GattService1> service );
     virtual void removeSubService( std::shared_ptr<GattService1> service );
     virtual const std::string& getPath() const final;
-    virtual std::shared_ptr<IConnection> getConnection() const final;
+    virtual std::shared_ptr<sdbus::IConnection> getConnection() const final;
     virtual int nextCharacteristicIndex() const final;
 
 public:

--- a/include/bluez-dbus-cpp/LEAdvertisement1.h
+++ b/include/bluez-dbus-cpp/LEAdvertisement1.h
@@ -13,8 +13,6 @@
 namespace org {
 namespace bluez {
 
-using namespace sdbus;
-
 class LEAdvertisement1 :
     public std::enable_shared_from_this<LEAdvertisement1>
 {
@@ -26,7 +24,7 @@ class LEAdvertisement1 :
     static constexpr const char* INTERFACE_NAME = "org.bluez.LEAdvertisement1";
 
 public:
-    LEAdvertisement1( IConnection& connection, std::string objectPath )
+    LEAdvertisement1( sdbus::IConnection& connection, std::string objectPath )
         : object_{ createObject(connection, objectPath) },
           path_{ std::move(objectPath) }
     {
@@ -43,7 +41,7 @@ public:
         return path_;
     }
 
-    static LEAdvertisement1& create( IConnection& connection, std::string objectPath )
+    static LEAdvertisement1& create( sdbus::IConnection& connection, std::string objectPath )
     {
         auto self = new LEAdvertisement1{ connection, std::move(objectPath) };
         return *self;

--- a/include/bluez-dbus-cpp/LEAdvertisingManager1.h
+++ b/include/bluez-dbus-cpp/LEAdvertisingManager1.h
@@ -11,8 +11,6 @@
 namespace org {
 namespace bluez {
 
-using namespace sdbus;
-
 class LEAdvertisingManager1 :
     public std::enable_shared_from_this<LEAdvertisingManager1>
 {
@@ -20,7 +18,7 @@ class LEAdvertisingManager1 :
     static constexpr const char* INTERFACE_NAME = "org.bluez.LEAdvertisingManager1";
 
 public:
-    LEAdvertisingManager1( IConnection& connection, std::string destination, std::string objectPath )
+    LEAdvertisingManager1( sdbus::IConnection& connection, std::string destination, std::string objectPath )
         : proxy_{ createProxy( connection, std::move(destination), std::move(objectPath) ) }
     {
         proxy_->finishRegistration();
@@ -43,7 +41,7 @@ public:
         proxy_->callMethod("RegisterAdvertisement").onInterface(INTERFACE_NAME).withArguments( advertisementPath, options );
     }
 
-    AsyncMethodInvoker RegisterAdvertisementAsync( const sdbus::ObjectPath& advertisementPath, const std::map<std::string, sdbus::Variant>& options = {} )
+    sdbus::AsyncMethodInvoker RegisterAdvertisementAsync( const sdbus::ObjectPath& advertisementPath, const std::map<std::string, sdbus::Variant>& options = {} )
     {
         return proxy_->callMethodAsync("RegisterAdvertisement").onInterface(INTERFACE_NAME).withArguments( advertisementPath, options );
     }

--- a/include/bluez-dbus-cpp/adaptor/ObjectManagerExt_adaptor.h
+++ b/include/bluez-dbus-cpp/adaptor/ObjectManagerExt_adaptor.h
@@ -14,7 +14,7 @@
 namespace org {
 namespace bluez {
 
-class ObjectManagerExt_adaptor : public ObjectManager_adaptor
+class ObjectManagerExt_adaptor : public sdbus::ObjectManager_adaptor
 {
 public:
     static constexpr const char* INTERFACE_NAME = "org.freedesktop.DBus.ObjectManager";

--- a/include/bluez-dbus-cpp/adaptor/PropertiesExt_adaptor.h
+++ b/include/bluez-dbus-cpp/adaptor/PropertiesExt_adaptor.h
@@ -8,9 +8,7 @@
 
 #include <sdbus-c++/sdbus-c++.h>
 
-using namespace sdbus;
-
-class PropertiesExt_adaptor : public Properties_adaptor
+class PropertiesExt_adaptor : public sdbus::Properties_adaptor
 {
 public:
     PropertiesExt_adaptor(sdbus::IObject& object)

--- a/src/GattCharacteristic1.cpp
+++ b/src/GattCharacteristic1.cpp
@@ -107,12 +107,12 @@ void GattCharacteristic1::addFlag( std::string flag )
 
 // ---- Default Handlers -------------------------------------------------------
 
-std::vector<uint8_t> GattCharacteristic1::ReadValue(const std::map<std::string, sdbus::Variant>& options)
+std::vector<uint8_t> GattCharacteristic1::ReadValue(const std::map<std::string, sdbus::Variant>& /*options*/)
 {
     return value_;
 }
 
-void GattCharacteristic1::WriteValue(const std::vector<uint8_t>& value, const std::map<std::string, sdbus::Variant>& options)
+void GattCharacteristic1::WriteValue(const std::vector<uint8_t>& value, const std::map<std::string, sdbus::Variant>& /*options*/)
 {
     value_ = value;
 }
@@ -122,22 +122,22 @@ std::map<sdbus::ObjectPath, std::vector<std::vector<uint8_t>>> GattCharacteristi
     throw sdbus::Error("org.bluez.Error.NotSupported", "Property 'GattCharacteristic1::DirectedValue' not overloaded!");
 }
 
-std::tuple<sdbus::UnixFd, uint16_t> GattCharacteristic1::AcquireWrite(const std::map<std::string, sdbus::Variant>& options)
+std::tuple<sdbus::UnixFd, uint16_t> GattCharacteristic1::AcquireWrite(const std::map<std::string, sdbus::Variant>& /*options*/)
 {
     throw sdbus::Error("org.bluez.Error.NotSupported", "Method 'GattCharacteristic1::AcquireWrite' not overloaded!");
 }
 
-std::tuple<sdbus::UnixFd, uint16_t> GattCharacteristic1::AcquireNotify(const std::map<std::string, sdbus::Variant>& options)
+std::tuple<sdbus::UnixFd, uint16_t> GattCharacteristic1::AcquireNotify(const std::map<std::string, sdbus::Variant>& /*options*/)
 {
     throw sdbus::Error("org.bluez.Error.NotSupported", "Method 'GattCharacteristic1::AcquireNotify' not overloaded!");
 }
 
-void GattCharacteristic1::StartNotify(const std::map<std::string, sdbus::Variant>& options)
+void GattCharacteristic1::StartNotify(const std::map<std::string, sdbus::Variant>& /*options*/)
 {
     notifyingSessions_ += 1;
 }
 
-void GattCharacteristic1::StopNotify(const std::map<std::string, sdbus::Variant>& options)
+void GattCharacteristic1::StopNotify(const std::map<std::string, sdbus::Variant>& /*options*/)
 {
     notifyingSessions_ -= 1;
 }
@@ -152,7 +152,7 @@ void GattCharacteristic1::addDescriptor( std::shared_ptr<GattDescriptor1> descri
 {
     const std::string& descPath = descriptor->getPath();
 
-    for( auto path : includes_ )
+    for( const auto & path : includes_ )
     {
         if( path == descPath )
             throw std::invalid_argument(std::string("GattCharacteristic1::addDescriptor '") + descPath + std::string("' already registered!"));

--- a/src/GattCharacteristic1.cpp
+++ b/src/GattCharacteristic1.cpp
@@ -190,7 +190,7 @@ const std::string& GattCharacteristic1::getPath() const
     return path_;
 }
 
-const std::shared_ptr<IConnection> GattCharacteristic1::getConnection() const
+const std::shared_ptr<sdbus::IConnection> GattCharacteristic1::getConnection() const
 {
     return service_->getConnection();
 }

--- a/src/GattService1.cpp
+++ b/src/GattService1.cpp
@@ -116,7 +116,7 @@ const std::string& GattService1::getPath() const
     return path_;
 }
 
-std::shared_ptr<IConnection> GattService1::getConnection() const
+std::shared_ptr<sdbus::IConnection> GattService1::getConnection() const
 {
     return app_->getConnection();
 }

--- a/src/GattService1.cpp
+++ b/src/GattService1.cpp
@@ -53,7 +53,7 @@ GattService1::~GattService1()
 
 void GattService1::addCharacteristic( std::shared_ptr<GattCharacteristic1> characteristic )
 {
-    for( auto chrc : characteristics_ )
+    for( const auto & chrc : characteristics_ )
     {
         if( chrc == characteristic )
             throw std::invalid_argument(std::string("GattService1::addCharacteristic '") + characteristic->getPath() + std::string("' already registered!"));
@@ -78,7 +78,7 @@ void GattService1::addSubService( std::shared_ptr<GattService1> service )
 {
     const std::string& srvPath = service->getPath();
 
-    for( auto path : includes_ )
+    for( const auto & path : includes_ )
     {
         if( path == srvPath )
             throw std::invalid_argument(std::string("GattService1::addSubService '") + srvPath + std::string("' already registered!"));


### PR DESCRIPTION
Just two small enhancements, to this very nice C++ bluez dbus layer.